### PR TITLE
changes of displaylists in R 3.0.0

### DIFF
--- a/R/graphics.r
+++ b/R/graphics.r
@@ -38,7 +38,7 @@ is_par_change <- function(p1, p2) {
   if (!identical(calls1, calls2[1:n1])) return(FALSE)
 
   last <- calls2[(n1 + 1):n2]
-  all(last %in% c("layout", "par", ".External2"))
+  all(last %in% c("layout", "par"))
 }
 
 


### PR DESCRIPTION
Now we should not treat `.External2` as "par" changes. See http://stackoverflow.com/q/16100382/559676 for an example, in which the second plot was incorrectly filtered out.
