### PR TITLE
Add terminating \n to comment src

### DIFF
--- a/R/parse.r
+++ b/R/parse.r
@@ -19,6 +19,7 @@ parse_all.character <- function(x) {
   # No code, all comments
   if (length(expr) == 0) {
     n <- length(x)
+    x <- paste(x, "\n", sep = "")
     return(data.frame(
       x1 = seq_along(x), x2 = seq_along(x),
       y1 = rep(0, n), y2 = nchar(x),


### PR DESCRIPTION
Normally, the src attributes of evaluate output has trailing `\n`:

```
> evaluate::evaluate(input = "ls()\nls()")
[[1]]
$src
[1] "ls()\n"

attr(,"class")
[1] "source"

[[2]]
[1] "character(0)\n"

[[3]]
$src
[1] "ls()"

attr(,"class")
[1] "source"

[[4]]
[1] "character(0)\n"
```

But not for comments:

```
> evaluate::evaluate(input = "#foo\n#bar")
[[1]]
$src
[1] "#foo"

attr(,"class")
[1] "source"

[[2]]
$src
[1] "#bar"

attr(,"class")
[1] "source"
```

This is causing staticdocs to render "dontrun" examples without hard returns at all (I can show you an example if you want).

With this change, `\n` is appended to each comment line. Note that the final line (`#bar` in the example above) will have a trailing `\n`, unlike the first example (`ls()\nls()`).
