### PR TITLE
Only call graphics handler when there is graphical output to process

### DIFF
--- a/R/watcher.r
+++ b/R/watcher.r
@@ -21,7 +21,7 @@ watchout <- function(debug = FALSE) {
 
       if (plot) {
         out$graphics <- plot_snapshot(incomplete_plots)
-        graphics_callback(out$graphics)
+        if (!is.null(out$graphics)) graphics_callback(out$graphics)
       }
 
       if (length(output) != length(prev)) {


### PR DESCRIPTION
Otherwise every graphics handler function has to start with a check for NULL.
