### PR TITLE
Avoid warnings for partial matching for incomplete error objects

### DIFF
--- a/R/traceback.r
+++ b/R/traceback.r
@@ -28,6 +28,10 @@ create_traceback <- function(callstack) {
 #' @export
 try_capture_stack <- function(quoted_code, env) {
   capture_calls <- function(e) {
+    # Make sure a "call" component exists to avoid warnings with partial
+    # matching in conditionCall.condition()
+    e["call"] <- e["call"]
+
     # Capture call stack, removing last two calls from end (added by
     # withCallingHandlers), and first frame + 7 calls from start (added by
     # tryCatch etc)


### PR DESCRIPTION
The warnings no longer occur with this pull request. Do we need a test?

``` r
options(warnPartialMatchDollar = TRUE)
e <- structure(list(message = "oops"), class = c("error", "condition"))
evaluate::try_capture_stack({
  stop(e)
})
#> Warning: partial match of 'call' to 'calls'

#> Warning: partial match of 'call' to 'calls'
#> <error in list(): oops>
```

> Created on 2018-02-21 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).