### PR TITLE
Allow user-supplied calling handlers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: evaluate
 Type: Package
 Title: Parsing and Evaluation Tools that Provide More Details than the Default
-Version: 0.14.1
+Version: 0.14.2
 Authors@R: c(
     person("Hadley", "Wickham", role = "aut"),
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 Version 0.15
 ================================================================================
 
-
+- `new_output_handler()` gains a `calling_handlers` argument. These are passed to `withCallingHandlers()` before `evaluate()` captures any conditions.
 
 Version 0.14
 ================================================================================

--- a/R/eval.r
+++ b/R/eval.r
@@ -190,12 +190,19 @@ evaluate_call <- function(call, src = NULL,
     for (i in seq_along(funs_names)) assign(funs_names[i], funs[[i]], envir)
   }
 
+  user_handlers <- output_handler$calling_handlers
+
   multi_args <- length(formals(value_handler)) > 1
   for (expr in call) {
     srcindex <- length(output)
-    time <- timing_fn(handle(ev <- withCallingHandlers(
-      withVisible(eval(expr, envir, enclos)),
-      warning = wHandler, error = eHandler, message = mHandler)))
+    time <- timing_fn(handle(
+      ev <- withCallingHandlers(
+        withVisible(eval_with_user_handlers(expr, envir, enclos, user_handlers)),
+        warning = wHandler,
+        error = eHandler,
+        message = mHandler
+      )
+    ))
     handle_output(TRUE)
     if (!is.null(time))
       attr(output[[srcindex]]$src, 'timing') <- time
@@ -220,6 +227,24 @@ evaluate_call <- function(call, src = NULL,
   }
 
   output
+}
+
+eval_with_user_handlers <- function(expr, envir, enclos, calling_handlers) {
+  if (!length(calling_handlers)) {
+    return(eval(expr, envir, enclos))
+  }
+
+  if (!is.list(calling_handlers)) {
+    stop("`calling_handlers` must be a list", call. = FALSE)
+  }
+
+  call <- as.call(c(
+    quote(withCallingHandlers),
+    quote(eval(expr, envir, enclos)),
+    calling_handlers
+  ))
+
+  eval(call)
 }
 
 #' Inject functions into the environment of `evaluate()`

--- a/man/new_output_handler.Rd
+++ b/man/new_output_handler.Rd
@@ -12,7 +12,8 @@ new_output_handler(
   message = identity,
   warning = identity,
   error = identity,
-  value = render
+  value = render,
+  calling_handlers = list()
 )
 }
 \arguments{
@@ -32,6 +33,10 @@ new_output_handler(
 \item{value}{Function to handle the values returned from evaluation. If it
 only has one argument, only visible values are handled; if it has more
 arguments, the second argument indicates whether the value is visible.}
+
+\item{calling_handlers}{List of \link[=withCallingHandlers]{calling handlers}.
+These handlers have precedence over the exiting handler installed
+by \code{\link[=evaluate]{evaluate()}} when \code{stop_on_error} is set to 0.}
 }
 \value{
 A new \code{output_handler} object


### PR DESCRIPTION
Registered in the innermost context so that they are called before capture with `try()`.

This allows registering `rlang::entrace()` to enrich all base errors and enable usage of `last_error()` in Rmd chunk.

Progress towards tidyverse/reprex#230.
cc @hadley @jennybc 