### PR TITLE
Rename `.env` to `the`

### DIFF
--- a/R/evaluate-package.R
+++ b/R/evaluate-package.R
@@ -1,6 +1,8 @@
 #' @keywords internal
 "_PACKAGE"
 
+the <- new.env(parent = emptyenv())
+
 ## usethis namespace: start
 ## usethis namespace: end
 NULL

--- a/R/flush-console.R
+++ b/R/flush-console.R
@@ -13,18 +13,18 @@
 #' either a direct `evaluate()` call or in \pkg{knitr} code chunks).
 #' @export
 flush_console = function() {
-  if (!is.null(.env$output_handler)) {
-    .env$output_handler()
+  if (!is.null(the$output_handler)) {
+    the$output_handler()
   }
   invisible()
 }
 
-.env = new.env()
-.env$output_handler <- NULL
+
+the$output_handler <- NULL
 
 set_output_handler <- function(handler) {
-  old <- .env$output_handler
-  .env$output_handler <- handler
+  old <- the$output_handler
+  the$output_handler <- handler
   invisible(old)
 } 
 

--- a/R/inject-funs.R
+++ b/R/inject-funs.R
@@ -27,14 +27,14 @@
 inject_funs <- function(...) {
   funs <- list(...)
   funs <- funs[names(funs) != '']
-  old <- .env$inject_funs
-  .env$inject_funs <- Filter(is.function, funs)
+  old <- the$inject_funs
+  the$inject_funs <- Filter(is.function, funs)
 
   invisible(old)
 }
 
 local_inject_funs <- function(envir, frame = parent.frame()) {
-  funs <- .env$inject_funs
+  funs <- the$inject_funs
   if (length(funs) == 0) {
     return()
   }

--- a/tests/testthat/test-flush-console.R
+++ b/tests/testthat/test-flush-console.R
@@ -7,7 +7,7 @@ test_that("flush_console() is a null op by default", {
 test_that("can set and restore output handler", {
   f <- function() message("Hi")
   old <- set_output_handler(function() message("Hi"))
-  expect_equal(.env$output_handler, f)
+  expect_equal(the$output_handler, f)
   expect_equal(old, NULL)
 
   expect_message(flush_console(), "Hi")


### PR DESCRIPTION
This is the convention we've adopted in the tidyverse because `the` does a nice job of implying that the object is a singleton.