### PR TITLE
Create clearer data structures for keep_message and keep_warning

### DIFF
--- a/R/eval.R
+++ b/R/eval.R
@@ -24,12 +24,18 @@
 #'     and you will get back all results up to that point. 
 #'   * If `2`, evaluation will halt on first error and you will get back no 
 #'     results.
-#' @param keep_warning,keep_message whether to record warnings and messages; if
-#'   `FALSE`, messages will be suppressed; if `NA`, they will not be captured
-#'   (normally they will be sent to the console). Note that if the environment
-#'   variable `R_EVALUATE_BYPASS_MESSAGES` is set to true, these arguments will
-#'   always be set to `NA`, meaning that messages will not be captured by this
-#'   function.
+#' @param keep_warning,keep_message A single logical value that controls what
+#'   happens to warnings and messages.
+#' 
+#'   * If `TRUE`, the default, warnings and messages will be captured in the
+#'     output.
+#'   * If `NA`, warnings and messages will not be captured and bubble up to
+#'     the calling environment of `evaluate()`.
+#'   * If `FALSE`, warnings and messages will be completed supressed and
+#'     not shown anywhere.
+#'     
+#'  Note that setting the envvar `R_EVALUATE_BYPASS_MESSAGES` to `true` will 
+#'  force these arguments to be set to `NA`.
 #' @param log_echo,log_warning If `TRUE`, will immediately log code and
 #'   warnings (respectively) to `stderr`.
 #' @param new_device if `TRUE`, will open a new graphics device and
@@ -62,6 +68,8 @@ evaluate <- function(input,
     keep_message <- NA 
     keep_warning <- NA
   }
+  on_message <- check_keep(keep_message, "keep_message")
+  on_warning <- check_keep(keep_warning, "keep_warning", log_warning)
 
   output_handler <- output_handler %||% default_output_handler
 
@@ -95,9 +103,8 @@ evaluate <- function(input,
       watcher = watcher,
       envir = envir,
       use_try = on_error != "error",
-      keep_warning = keep_warning,
-      keep_message = keep_message,
-      log_warning = log_warning,
+      on_warning = on_warning,
+      on_message = on_message,
       output_handler = output_handler
     )
     watcher$check_devices()
@@ -118,8 +125,8 @@ evaluate_top_level_expression <- function(exprs,
                                           watcher,
                                           envir = parent.frame(),
                                           use_try = FALSE,
-                                          keep_warning = TRUE,
-                                          keep_message = TRUE,
+                                          on_warning,
+                                          on_message,
                                           log_warning = FALSE,
                                           output_handler = new_output_handler()) {
   stopifnot(is.expression(exprs))
@@ -139,31 +146,27 @@ evaluate_top_level_expression <- function(exprs,
   # Handlers for warnings, errors and messages
   mHandler <- function(cnd) {
     handle_output()
-    if (isTRUE(keep_message)) {
+    
+    if (on_message$capture) {
       watcher$push(cnd)
       output_handler$message(cnd)
-      invokeRestart("muffleMessage")
-    } else if (isFALSE(keep_message)) {
+    }
+    if (on_message$silence) {
       invokeRestart("muffleMessage")
     }
   }
   wHandler <- function(cnd) {
-    # do not handle warnings that shortly become errors
-    if (getOption("warn") >= 2) return()
-    # do not handle warnings that have been completely silenced
-    if (getOption("warn") < 0) return()
-
-    if (log_warning) {
-      cat_line(format_condition(cnd), file = stderr())
-    }
+    # don't warnings that shortly become errors or have been silenced
+    warn <- getOption("warn")
+    if (warn >= 2 || warn < 0) return()
 
     handle_output()
-    if (isTRUE(keep_warning)) {
+    if (on_warning$capture) {
       cnd <- reset_call(cnd)
       watcher$push(cnd)
       output_handler$warning(cnd)
-      invokeRestart("muffleWarning")
-    } else if (isFALSE(keep_warning)) {
+    }
+    if (on_warning$silence) {
       invokeRestart("muffleWarning")
     }
   }
@@ -251,5 +254,16 @@ check_stop_on_error <- function(x) {
       return("error")
     }
   }
-  stop("`stop_on_error` must be 0, 1, or 2 ", call. = FALSE)
+  stop("`stop_on_error` must be 0, 1, or 2.", call. = FALSE)
+}
+
+check_keep <- function(x, arg, log = FALSE) {
+  if (!is.logical(x) || length(x) != 1) {
+    stop("`", arg, "` must be TRUE, FALSE, or NA.", call. = FALSE)
+  }
+
+  list(
+    capture = isTRUE(x),
+    silence = !is.na(x) && !log
+  )
 }

--- a/R/eval.R
+++ b/R/eval.R
@@ -107,7 +107,7 @@ evaluate <- function(input,
           on_error = on_error,
           on_warning = on_warning,
           on_message = on_message,
-              output_handler = output_handler
+          output_handler = output_handler
         )
         TRUE
       },

--- a/R/eval.R
+++ b/R/eval.R
@@ -156,7 +156,7 @@ evaluate_top_level_expression <- function(exprs,
     }
   }
   wHandler <- function(cnd) {
-    # don't warnings that shortly become errors or have been silenced
+    # don't handle warnings that are errors or have been silenced
     warn <- getOption("warn")
     if (warn >= 2 || warn < 0) return()
 

--- a/R/eval.R
+++ b/R/eval.R
@@ -156,9 +156,10 @@ evaluate_top_level_expression <- function(exprs,
     }
   }
   wHandler <- function(cnd) {
-    # don't handle warnings that are errors or have been silenced
-    warn <- getOption("warn")
-    if (warn >= 2 || warn < 0) return()
+    # do not handle warnings that shortly become errors
+    if (getOption("warn") >= 2) return()
+    # do not handle warnings that have been completely silenced
+    if (getOption("warn") < 0) return()
 
     handle_output()
     if (on_warning$capture) {

--- a/man/evaluate.Rd
+++ b/man/evaluate.Rd
@@ -43,12 +43,19 @@ and you will get back all results up to that point.
 results.
 }}
 
-\item{keep_warning, keep_message}{whether to record warnings and messages; if
-\code{FALSE}, messages will be suppressed; if \code{NA}, they will not be captured
-(normally they will be sent to the console). Note that if the environment
-variable \code{R_EVALUATE_BYPASS_MESSAGES} is set to true, these arguments will
-always be set to \code{NA}, meaning that messages will not be captured by this
-function.}
+\item{keep_warning, keep_message}{A single logical value that controls what
+happens to warnings and messages.
+\itemize{
+\item If \code{TRUE}, the default, warnings and messages will be captured in the
+output.
+\item If \code{NA}, warnings and messages will not be captured and bubble up to
+the calling environment of \code{evaluate()}.
+\item If \code{FALSE}, warnings and messages will be completed supressed and
+not shown anywhere.
+}
+
+Note that setting the envvar \code{R_EVALUATE_BYPASS_MESSAGES} to \code{true} will
+force these arguments to be set to \code{NA}.}
 
 \item{log_echo, log_warning}{If \code{TRUE}, will immediately log code and
 warnings (respectively) to \code{stderr}.}

--- a/tests/testthat/_snaps/conditions.md
+++ b/tests/testthat/_snaps/conditions.md
@@ -1,3 +1,11 @@
+# log_warning causes warnings to be emitted
+
+    Code
+      ev <- evaluate("f()", log_warning = TRUE)
+    Condition
+      Warning in `f()`:
+      Hi!
+
 # all three starts of stop_on_error work as expected
 
     Code

--- a/tests/testthat/_snaps/eval.md
+++ b/tests/testthat/_snaps/eval.md
@@ -4,5 +4,18 @@
       check_stop_on_error(4)
     Condition
       Error:
-      ! `stop_on_error` must be 0, 1, or 2 
+      ! `stop_on_error` must be 0, 1, or 2.
+
+# check_keep errors with bad inputs
+
+    Code
+      check_keep(1, "keep_message")
+    Condition
+      Error:
+      ! `keep_message` must be TRUE, FALSE, or NA.
+    Code
+      check_keep(c(TRUE, FALSE), "keep_message")
+    Condition
+      Error:
+      ! `keep_message` must be TRUE, FALSE, or NA.
 

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -90,19 +90,16 @@ test_that("all three states of keep_warning work as expected", {
   expect_output_types(ev, "source")
 })
 
-test_that("log_warning causes warnings to be immediately written to stderr()", {
+test_that("log_warning causes warnings to be emitted", {
   f <- function() {
     warning("Hi!", immediate. = TRUE)
   }
-  out <- capture.output(
-    res <- evaluate("f()", log_warning = TRUE),
-    type = "message"
-  )
-  expect_equal(out, c("Warning in f():", "Hi!"))
+  expect_snapshot(ev <- evaluate("f()", log_warning = TRUE))
 
-  # But still recorded in eval result
-  expect_equal(res[[1]]$src, "f()")
-  expect_equal(res[[2]], simpleWarning("Hi!", quote(f())))
+  # And still recorded in eval result
+  expect_output_types(ev, c("source", "warning"))
+  expect_equal(ev[[1]]$src, "f()")
+  expect_equal(ev[[2]], simpleWarning("Hi!", quote(f())))
 })
 
 # errors ----------------------------------------------------------------------

--- a/tests/testthat/test-eval.R
+++ b/tests/testthat/test-eval.R
@@ -92,3 +92,27 @@ test_that("check_stop_on_error converts integer to enum", {
 
   expect_snapshot(check_stop_on_error(4), error = TRUE)
 })
+
+test_that("check_keep converts to logical as expected", {
+  expect_true(check_keep(TRUE)$capture)
+  expect_false(check_keep(NA)$capture)
+  expect_false(check_keep(FALSE)$capture)
+  
+  expect_true(check_keep(TRUE)$silence)
+  expect_false(check_keep(NA)$silence)
+  expect_true(check_keep(FALSE)$silence)
+})
+
+test_that("check_keep can integrate log option", {
+  # logging means we never silence the ouptut
+  expect_false(check_keep(TRUE, log = TRUE)$silence)
+  expect_false(check_keep(NA, log = TRUE)$silence)
+  expect_false(check_keep(FALSE, log = TRUE)$silence)
+})
+
+test_that("check_keep errors with bad inputs", {
+  expect_snapshot(error = TRUE, {
+    check_keep(1, "keep_message")
+    check_keep(c(TRUE, FALSE), "keep_message")
+  })
+})


### PR DESCRIPTION
Like the similar change for `stop_on_error`, I think this change makes it easier to reason about what's going on.

I think this also better captures my original motivation for adding the `log_warnings` argument; you want some way to say "please capture warnings while continuing to show them in the console.". I'm not sure about the field names here, so please let me know if you have better ideas.