### PR TITLE
Consistently strip trailing `\n` when parsing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # evaluate (development version)
 
+* `parse_all()` consistently strips the trailing `\n` from the end of each `src` vector.
 * The package now depends on R 4.0.0 in order to decrease our maintenance burden.
 * `evaluate()` automatically strips calls from conditions emitted by top-level code (these incorrectly get calls because they're wrapped inside `eval()`) (#150).
 * `evalute(include_timing)` has been deprecated. I can't find any use of it on GitHub, and it adds substantial code complexity for little gain.

--- a/R/parse.R
+++ b/R/parse.R
@@ -70,7 +70,7 @@ parse_all.character <- function(x, filename = NULL, allow_error = FALSE) {
 
   srcref <- attr(exprs, "srcref", exact = TRUE)
 
-  # Start/Ene line numbers of expressions
+  # Start/end line numbers of expressions
   pos <- do.call(rbind, lapply(srcref, unclass))[, c(7, 8), drop = FALSE]
   l1 <- pos[, 1]
   l2 <- pos[, 2]

--- a/R/parse.R
+++ b/R/parse.R
@@ -83,9 +83,9 @@ parse_all.character <- function(x, filename = NULL, allow_error = FALSE) {
   res <- lapply(split(pos, spl), function(p) {
     n <- nrow(p)
     data.frame(
-      src = paste(x[p$start[1]:p$end[n]], collapse = "\n", recycle0 = TRUE),
-      expr = I(list(exprs[p[, 3]])),
-      line = p[1, 1]
+      src = paste(x[p$start[1]:p$end[n]], collapse = "\n"),
+      expr = I(list(exprs[p$i])),
+      line = p$start[1]
     )
   })
 

--- a/R/parse.R
+++ b/R/parse.R
@@ -13,7 +13,7 @@
 #' top-level expression in `x`. A top-level expression is a complete expression 
 #' which would trigger execution if typed at the console. 
 #' 
-#' The trailing `\n` at the end of each `src` is implicit.`
+#' The trailing `\n` at the end of each `src` is implicit.
 #' 
 #' The `expression` object in `expr` can be of any length: it will be 0 if 
 #' the top-level expression contains only whitespace and/or comments; 1 if 

--- a/R/parse.R
+++ b/R/parse.R
@@ -71,7 +71,7 @@ parse_all.character <- function(x, filename = NULL, allow_error = FALSE) {
   srcref <- attr(exprs, "srcref", exact = TRUE)
   pos <- data.frame(
     start = vapply(srcref, `[[`, 7, FUN.VALUE = integer(1)),
-    end = vapply(srcref, `[`, 8, FUN.VALUE = integer(1)),
+    end = vapply(srcref, `[[`, 8, FUN.VALUE = integer(1)),
     i = seq_along(srcref)
   )
 

--- a/man/parse_all.Rd
+++ b/man/parse_all.Rd
@@ -18,12 +18,15 @@ If a connection, will be opened and closed only if it was closed initially.}
 A data frame with columns \code{src}, a character vector of source code, and
 \code{expr}, a list-column of parsed expressions. There will be one row for each
 top-level expression in \code{x}. A top-level expression is a complete expression
-which would trigger execution if typed at the console. The \code{expression}
-object in \code{expr} can be of any length: it will be 0 if the top-level
-expression contains only whitespace and/or comments; 1 if the top-level
-expression is a single scalar (like \code{TRUE}, \code{1}, or \code{"x"}), name, or call;
-or 2 if the top-level expression uses \verb{;} to put multiple expressions on
-one line.
+which would trigger execution if typed at the console.
+
+The trailing \verb{\\n} at the end of each \code{src} is implicit.`
+
+The \code{expression} object in \code{expr} can be of any length: it will be 0 if
+the top-level expression contains only whitespace and/or comments; 1 if
+the top-level expression is a single scalar (like \code{TRUE}, \code{1}, or \code{"x"}),
+name, or call; or 2 if the top-level expression uses \verb{;} to put multiple
+expressions on one line.
 
 If there are syntax errors in \code{x} and \code{allow_error = TRUE}, the data
 frame will have an attribute \code{PARSE_ERROR} that stores the error object.

--- a/man/parse_all.Rd
+++ b/man/parse_all.Rd
@@ -20,7 +20,7 @@ A data frame with columns \code{src}, a character vector of source code, and
 top-level expression in \code{x}. A top-level expression is a complete expression
 which would trigger execution if typed at the console.
 
-The trailing \verb{\\n} at the end of each \code{src} is implicit.`
+The trailing \verb{\\n} at the end of each \code{src} is implicit.
 
 The \code{expression} object in \code{expr} can be of any length: it will be 0 if
 the top-level expression contains only whitespace and/or comments; 1 if

--- a/tests/testthat/test-eval.R
+++ b/tests/testthat/test-eval.R
@@ -79,12 +79,6 @@ test_that("multiple expressions on one line can get printed as expected", {
   expect_output_types(ev, c("source", "text", "text"))
 })
 
-test_that("multiple lines of comments do not lose the terminating \\n", {
-  ev <- evaluate("# foo\n#bar")
-  expect_output_types(ev, c("source", "source"))
-  expect_equal(ev[[1]]$src, "# foo\n")
-})
-
 test_that("check_stop_on_error converts integer to enum", {
   expect_equal(check_stop_on_error(0), "continue")
   expect_equal(check_stop_on_error(1), "stop")

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -16,6 +16,24 @@ test_that("a character vector is equivalent to a multi-line string", {
   expect_equal(parse_all(c("a", "b")), parse_all(c("a\nb")))
 })
 
+test_that("recombines multi-expression TLEs", {
+  expect_equal(
+    parse_all("1;2;3")$expr[[1]],
+    expression(1, 2, 3),
+    ignore_attr = "srcref"
+  )
+  expect_equal(
+    parse_all("1+\n2;3")$expr[[1]],
+    expression(1 + 2, 3),
+    ignore_attr = "srcref"
+  )
+  expect_equal(
+    parse_all("1+\n2;3+\n4; 5")$expr[[1]],
+    expression(1 + 2, 3 + 4, 5),
+    ignore_attr = "srcref"
+  )
+})
+
 test_that("expr is always an expression", {
   expect_equal(parse_all("#")$expr[[1]], expression())
   expect_equal(parse_all("1")$expr[[1]], expression(1), ignore_attr = "srcref")

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1,3 +1,9 @@
+test_that("can parse even if no expressions", {
+  expect_equal(parse_all("")$src, "")
+  expect_equal(parse_all("#")$src, "#")
+  expect_equal(parse_all("#\n\n")$src, c("#", ""))
+})
+
 test_that("every TLE has an implicit nl", {
   expect_equal(parse_all("x")$src, "x")
   expect_equal(parse_all("x\n")$src, "x")
@@ -32,6 +38,11 @@ test_that("recombines multi-expression TLEs", {
     expression(1 + 2, 3 + 4, 5),
     ignore_attr = "srcref"
   )
+})
+
+test_that("re-integrates lines without expressions", {
+  expect_equal(parse_all("1\n\n2")$src, c("1", "", "2"))
+  expect_equal(parse_all("1\n#\n2")$src, c("1", "#", "2"))
 })
 
 test_that("expr is always an expression", {

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1,3 +1,21 @@
+test_that("every TLE has an implicit nl", {
+  expect_equal(parse_all("x")$src, "x")
+  expect_equal(parse_all("x\n")$src, "x")
+  expect_equal(parse_all("")$src, "")
+  expect_equal(parse_all("\n")$src, "")
+
+  expect_equal(parse_all("{\n1\n}")$src, "{\n1\n}")
+  expect_equal(parse_all("{\n1\n}\n")$src, "{\n1\n}")
+
+  # even empty lines
+  expect_equal(parse_all("a\n\nb")$src, c("a", "", "b"))
+  expect_equal(parse_all("\n\n")$src, c("", ""))
+})
+
+test_that("a character vector is equivalent to a multi-line string", {
+  expect_equal(parse_all(c("a", "b")), parse_all(c("a\nb")))
+})
+
 test_that("expr is always an expression", {
   expect_equal(parse_all("#")$expr[[1]], expression())
   expect_equal(parse_all("1")$expr[[1]], expression(1), ignore_attr = "srcref")
@@ -34,7 +52,7 @@ if (isTRUE(l10n_info()[['UTF-8']])) {
 
   test_that("multibyte characters are parsed correct", {
     code <- c("ϱ <- 1# g / ml", "äöüßÄÖÜπ <- 7 + 3# nonsense")
-    expect_identical(parse_all(code)$src, append_break(code))
+    expect_identical(parse_all(code)$src, code)
   })
 }
 


### PR DESCRIPTION
I can't tell what the original logic was supposed to be, and it seemed inconsistent. Given that the newline was sometimes present and sometimes absent, I assume downstream code must already deal with the differences so this change won't break anything, but we'll need to double-check that. I have confirmed that all testthat tests still pass and it doesn't affect any snapshot output.

Includes some code quality improvements.