### PR TITLE
Better function parsing

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -23,3 +23,20 @@ compact <- function(x) {
 env_var_is_true <- function(x) {
   isTRUE(as.logical(Sys.getenv(x, "false")))
 }
+
+is_call <- function(x, name) {
+  if (!is.call(x)) {
+    return(FALSE)
+  }
+  is.name(x[[1]]) && as.character(x[[1]]) %in% name
+}
+
+last <- function(x) x[length(x)]
+
+seq2 <- function(start, end, by = 1) {
+  if (start > end) {
+    integer()
+  } else {
+    seq(start, end, by = 1)
+  }
+}

--- a/tests/testthat/_snaps/replay.md
+++ b/tests/testthat/_snaps/replay.md
@@ -11,12 +11,15 @@
     Code
       replay(ev)
     Output
-      > f()
+      > print("1")
       [1] "1"
+      > message("2")
       2
-      Warning in f():
+      > warning("3")
+      Warning:
       3
-      Error in f():
+      > stop("4")
+      Error:
       4
 
 # replay handles rlang conditions
@@ -24,11 +27,13 @@
     Code
       replay(ev)
     Output
-      > f()
+      > rlang::inform("2")
       2
+      > rlang::warn("3")
       Warning:
       3
-      Error in f():
+      > rlang::abort("4", call = NULL)
+      Error:
       4
 
 # format_condition handles different types of warning

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,12 +1,3 @@
-evaluate_ <- function(text, ..., envir = parent.frame()) {
-  # Trim off leading/trailing new lines and dedent
-  text <- gsub("^\n {4}", "", text)
-  text <- gsub("\n {4}", "\n", text)
-  text <- gsub("\n +$", "", text)
-  
-  evaluate(text, ..., envir = envir)
-}
-
 expect_output_types <- function(x, types) {
   output_types <- vapply(x, output_type, character(1))
   expect_equal(output_types, types)

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -106,7 +106,7 @@ test_that("log_warning causes warnings to be emitted", {
 
 test_that("all three starts of stop_on_error work as expected", {
 
-  ev <- evaluate_('stop("1")\n2', stop_on_error = 0L)
+  ev <- evaluate('stop("1")\n2', stop_on_error = 0L)
   expect_output_types(ev, c("source", "error", "source", "text"))
 
   ev <- evaluate('stop("1")\n2', stop_on_error = 1L)

--- a/tests/testthat/test-eval.R
+++ b/tests/testthat/test-eval.R
@@ -1,9 +1,9 @@
 
 test_that("file with only comments runs", {
-  ev <- evaluate_("
+  ev <- evaluate(function() {
     # This test case contains no executable code
     # but it shouldn't throw an error
-  ")
+  })
   expect_output_types(ev, c("source", "source"))
 })
 
@@ -34,10 +34,10 @@ test_that("log_echo causes output to be immediately written to stderr()", {
 test_that("data sets loaded", {
   skip_if_not_installed("lattice")
 
-  ev <- evaluate_('
+  ev <- evaluate(function() {
     data(barley, package = "lattice")
     barley
-  ')
+  })
   expect_output_types(ev, c("source", "source", "text"))
 })
 
@@ -57,20 +57,20 @@ test_that("S4 methods are displayed with show, not print", {
 })
 
 test_that("output and plots interleaved correctly", {
-  ev <- evaluate_("
+  ev <- evaluate(function() {
     for (i in 1:2) {
       cat(i)
       plot(i)
     }
-  ")
+  })
   expect_output_types(ev, c("source", "text", "plot", "text", "plot"))
 
-  ev <- evaluate_("
+  ev <- evaluate(function() {
     for (i in 1:2) {
       plot(i)
       cat(i)
     }
-  ")
+  })
   expect_output_types(ev, c("source", "plot", "text", "plot", "text"))
 })
 

--- a/tests/testthat/test-output-handler.R
+++ b/tests/testthat/test-output-handler.R
@@ -60,14 +60,15 @@ test_that("source handled called correctly when src is unparseable", {
 test_that("return value of value handler inserted directly in output list", {
   skip_if_not_installed("ggplot2")
 
-  ev <- evaluate_('
-    rnorm(10)
-    x <- list("I\'m a list!")
-    suppressPackageStartupMessages(library(ggplot2))
-    ggplot(mtcars, aes(mpg, wt)) + geom_point()
-  ', output_handler = new_output_handler(value = identity)
+  ev <- evaluate(
+    function() {
+      rnorm(10)
+      x <- list("I\'m a list!")
+      ggplot2::ggplot(mtcars, ggplot2::aes(mpg, wt))
+    },
+    output_handler = new_output_handler(value = identity)
   )
-  expect_output_types(ev, c("source", "numeric", "source", "source", "source", "gg"))
+  expect_output_types(ev, c("source", "numeric", "source", "source", "gg"))
 })
 
 test_that("invisible values can also be saved if value handler has two arguments", {
@@ -96,4 +97,3 @@ test_that("user can register calling handlers", {
   evaluate("stop('tilt')", stop_on_error = 0, output_handler = out_hnd)
   expect_s3_class(handled, "error")
 })
-

--- a/tests/testthat/test-replay.R
+++ b/tests/testthat/test-replay.R
@@ -11,25 +11,21 @@ test_that("replay() should work when print() returns visible NULLs", {
 })
 
 test_that("replay handles various output types", {
-  f <- function() {
+  ev <- evaluate(function() {
     print("1")
     message("2")
     warning("3")
     stop("4")
-  }
-
-  ev <- evaluate("f()")
+  })
   expect_snapshot(replay(ev))
 })
 
 test_that("replay handles rlang conditions", {
-  f <- function() {
+  ev <- evaluate(function() {
     rlang::inform("2")
     rlang::warn("3")
-    rlang::abort("4")
-  }
-
-  ev <- evaluate("f()")
+    rlang::abort("4", call = NULL)
+  })
   expect_snapshot(replay(ev))
 })
 

--- a/tests/testthat/test-watcher.R
+++ b/tests/testthat/test-watcher.R
@@ -3,7 +3,7 @@ test_that("capture messages in try() (#88)", {
   f <- function(x) stop(paste0("Obscure ", x))
   g <- function() f("error")
 
-  ev <- evaluate_('try(g())')
+  ev <- evaluate('try(g())')
   expect_output_types(ev, c("source", "text"))
   expect_match(ev[[2]], "Obscure error")
 })
@@ -39,7 +39,11 @@ test_that("evaluate recovers from closed sink", {
 
 test_that("unbalanced sink doesn't break evaluate", {
   path <- withr::local_tempfile()
-  ev <- evaluate("sink(path)\n1\n1")
+  ev <- evaluate(function() {
+    sink(path)
+    1
+    1
+  })
   expect_output_types(ev, c("source", "source", "source"))
 })
 


### PR DESCRIPTION
The original intent of this code (as much as I can remember) was to make it easier to generate multiline examples by wrapping them in an anonymous zero-argument function (the simplest structure that preserves srcrefs). But I'm not sure the code ever worked properly so I reimplemented it from first principles a considerably cleaner approach.

This is a robust alternative to the testing helper `evaluate_()`, allowing me to eliminate that helper.