### PR TITLE
Strip srcrefs from exprs

### DIFF
--- a/R/parse.R
+++ b/R/parse.R
@@ -18,7 +18,7 @@
 #' expression contains only whitespace and/or comments; 1 if the top-level 
 #' expression is a single scalar (like `TRUE`, `1`, or `"x"`), name, or call; 
 #' or 2 if the top-level expression uses `;` to put multiple expressions on 
-#' one line.
+#' one line. The expressions have their srcrefs removed.
 #' 
 #' If there are syntax errors in `x` and `allow_error = TRUE`, the data 
 #' frame will have an attribute `PARSE_ERROR` that stores the error object.
@@ -104,6 +104,8 @@ parse_all.character <- function(x, filename = NULL, allow_error = FALSE) {
   nl <- c(rep("\n", nrow(res) - 1), if (trailing_nl) "\n" else "")
   res$src <- paste0(res$src, nl)
   
+  res$expr <- lapply(res$expr, removeSource)
+
   rownames(res) <- NULL
   res
 }

--- a/man/parse_all.Rd
+++ b/man/parse_all.Rd
@@ -17,13 +17,15 @@ If a connection, will be opened and closed only if it was closed initially.}
 \value{
 A data frame with columns \code{src}, a character vector of source code, and
 \code{expr}, a list-column of parsed expressions. There will be one row for each
-top-level expression in \code{x}. A top-level expression is a complete expression
+top-level expression in \code{x}.
+
+A top-level expression is a complete expression
 which would trigger execution if typed at the console. The \code{expression}
 object in \code{expr} can be of any length: it will be 0 if the top-level
 expression contains only whitespace and/or comments; 1 if the top-level
 expression is a single scalar (like \code{TRUE}, \code{1}, or \code{"x"}), name, or call;
 or 2 if the top-level expression uses \verb{;} to put multiple expressions on
-one line.
+one line. The expressions have their srcrefs removed.
 
 If there are syntax errors in \code{x} and \code{allow_error = TRUE}, the data
 frame will have an attribute \code{PARSE_ERROR} that stores the error object.

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -39,20 +39,11 @@ test_that("a character vector is equivalent to a multi-line string", {
 })
 
 test_that("recombines multi-expression TLEs", {
-  expect_equal(
-    parse_all("1;2;3")$expr[[1]],
-    expression(1, 2, 3),
-    ignore_attr = "srcref"
-  )
-  expect_equal(
-    parse_all("1+\n2;3")$expr[[1]],
-    expression(1 + 2, 3),
-    ignore_attr = "srcref"
-  )
+  expect_equal(parse_all("1;2;3")$expr[[1]], expression(1, 2, 3))
+  expect_equal(parse_all("1+\n2;3")$expr[[1]], expression(1 + 2, 3))
   expect_equal(
     parse_all("1+\n2;3+\n4; 5")$expr[[1]],
-    expression(1 + 2, 3 + 4, 5),
-    ignore_attr = "srcref"
+    expression(1 + 2, 3 + 4, 5)
   )
 })
 
@@ -63,8 +54,8 @@ test_that("re-integrates lines without expressions", {
 
 test_that("expr is always an expression", {
   expect_equal(parse_all("#")$expr[[1]], expression())
-  expect_equal(parse_all("1")$expr[[1]], expression(1), ignore_attr = "srcref")
-  expect_equal(parse_all("1;2")$expr[[1]], expression(1, 2), ignore_attr = "srcref")
+  expect_equal(parse_all("1")$expr[[1]], expression(1))
+  expect_equal(parse_all("1;2")$expr[[1]], expression(1, 2))
 
   parsed <- parse_all("#\n1\n1;2")
   expect_equal(lengths(parsed$expr), c(0, 1, 2))
@@ -84,7 +75,7 @@ test_that("double quotes in Chinese characters not destroyed", {
 
   out <- parse_all(c('1+1', '"你好"'))
   expect_equal(out$src[[2]], '"你好"')
-  expect_equal(out$expr[[2]], expression("你好"), ignore_attr = "srcref")
+  expect_equal(out$expr[[2]], expression("你好"))
 })
 
 test_that("multibyte characters are parsed correctly", {
@@ -100,11 +91,7 @@ test_that("multibyte characters are parsed correctly", {
 test_that("can parse a call", {
   out <- parse_all(quote(f(a, b, c)))
   expect_equal(out$src, "f(a, b, c)")
-  expect_equal(
-    out$expr,
-    I(list(expression(f(a, b, c)))),
-    ignore_attr = "srcref"
-  )
+  expect_equal(out$expr, list(expression(f(a, b, c))))
 })
 
 test_that("can parse a connection", {
@@ -115,11 +102,7 @@ test_that("can parse a connection", {
   out <- parse_all(con)
 
   expect_equal(out$src, c("# 1\n", "1 + 1"))
-  expect_equal(
-    out$expr,
-    I(list(expression(), expression(1 + 1))),
-    ignore_attr = "srcref"
-  )
+  expect_equal(out$expr, list(expression(), expression(1 + 1)))
 
   # Doesn't leave any connections around
   expect_equal(getAllConnections(), cur_cons)
@@ -131,11 +114,7 @@ test_that("can parse a function", {
     1 + 1
   })
   expect_equal(out$src, c("# Hi\n", "1 + 1"))
-  expect_equal(
-    out$expr,
-    I(list(expression(), expression(1 + 1))),
-    ignore_attr = "srcref"
-  )
+  expect_equal(out$expr, list(expression(), expression(1 + 1)))
 })
 
 # find_function_body -----------------------------------------------------------


### PR DESCRIPTION
This makes the output type simpler and makes testing a little easier.