### PR TITLE
Simplify handling of parse failures

### DIFF
--- a/R/eval.R
+++ b/R/eval.R
@@ -80,12 +80,14 @@ evaluate <- function(input,
   # Capture output
   watcher <- watchout(output_handler, new_device = new_device, debug = debug)
 
-  parsed <- parse_all(input, filename, on_error != "error")
-  if (inherits(err <- attr(parsed, 'PARSE_ERROR'), 'error')) {
-    watcher$push_source(parsed$src, expression())
+  if (on_error != "error" && !can_parse(input)) {
+    err <- tryCatch(parse(text = input), error = function(cnd) cnd) 
+    watcher$push_source(input, expression())
     watcher$push(err)
     return(watcher$get())
   }
+  
+  parsed <- parse_all(input, filename = filename)
   # "Transpose" parsed so we get a list that's easier to iterate over
   tles <- Map(
     function(src, exprs) list(src = src, exprs = exprs),

--- a/R/utils.R
+++ b/R/utils.R
@@ -36,3 +36,17 @@ seq2 <- function(start, end, by = 1) {
     seq(start, end, by = 1)
   }
 }
+
+can_parse <- function(x) {
+  if (!is.character(x)) {
+    return(TRUE)
+  }
+
+  tryCatch(
+    {
+      parse(text = x)
+      TRUE
+    },
+    error = function(e) FALSE
+  )
+}


### PR DESCRIPTION
This makes the logic a bit more clear, and simplifies the output of `parse_all()`. 

I haven't changed `parse_all()` since it looks like people are relying on this behaviour elsewhere.