### PR TITLE
Always return a bool from restarts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # evaluate (development version)
 
+* Fix buglet revealed when by using `rlang::abort()` inside of `evaluate()`.
+
 # evaluate 1.0.0
 
 * Setting `ACTIONS_STEP_DEBUG=1` (as in a failing GHA workflow) will

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -152,7 +152,7 @@ evaluate <- function(input,
       ),
       eval_continue = function() TRUE,
       eval_stop = function() FALSE,
-      eval_error = function(cnd) signalCondition(cnd)
+      eval_error = function(cnd) {signalCondition(cnd); FALSE}
     )
     watcher$check_devices()
 


### PR DESCRIPTION
Fixes #225

I can't remember exactly why this comes up, but clearly in some circumstances rethrowing the error doesn't trigger immediate termination. This shouldn't have widespread effects.

I can't figure out how to test this, but I confirmed that it fixed the reported bug when rendering a qmd.