### PR TITLE
add rlang min requirement and update snapshot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Suggests:
     lattice,
     methods,
     pkgload,
-    rlang,
+    rlang (>= 1.1.5),
     knitr,
     testthat (>= 3.0.0),
     withr

--- a/tests/testthat/_snaps/conditions/rmd-abort-error.txt
+++ b/tests/testthat/_snaps/conditions/rmd-abort-error.txt
@@ -4,11 +4,12 @@ processing file: ressources/with-abort-error.Rmd
 Error in `h()`:
 ! !
 Backtrace:
-    ▆
- 1. └─global f()
- 2.   └─global g()
- 3.     └─global h()
- 4.       └─rlang::abort("!")
+    x
+ 1. \-global f()
+ 2.   \-global g()
+ 3.     \-global h()
+ 4.       \-rlang::abort("!")
 
 Quitting from lines 6-10 [unnamed-chunk-1] (ressources/with-abort-error.Rmd)
 Execution halted
+Ran 8/8 deferred expressions

--- a/tests/testthat/_snaps/conditions/rmd-abort-error.txt
+++ b/tests/testthat/_snaps/conditions/rmd-abort-error.txt
@@ -4,9 +4,11 @@ processing file: ressources/with-abort-error.Rmd
 Error in `h()`:
 ! !
 Backtrace:
- 1. global f()
- 2. global g()
- 3. global h()
+    ▆
+ 1. └─global f()
+ 2.   └─global g()
+ 3.     └─global h()
+ 4.       └─rlang::abort("!")
 
 Quitting from lines 6-10 [unnamed-chunk-1] (ressources/with-abort-error.Rmd)
 Execution halted

--- a/tests/testthat/_snaps/conditions/rmd-stop-error-auto-entrace.txt
+++ b/tests/testthat/_snaps/conditions/rmd-stop-error-auto-entrace.txt
@@ -4,10 +4,11 @@ processing file: ressources/with-stop-error-auto-entrace.Rmd
 Error in `h()`:
 ! !
 Backtrace:
-    ▆
- 1. └─global f()
- 2.   └─global g()
- 3.     └─global h()
+    x
+ 1. \-global f()
+ 2.   \-global g()
+ 3.     \-global h()
 
 Quitting from lines 6-10 [unnamed-chunk-1] (ressources/with-stop-error-auto-entrace.Rmd)
 Execution halted
+Ran 8/8 deferred expressions

--- a/tests/testthat/_snaps/conditions/rmd-stop-error-auto-entrace.txt
+++ b/tests/testthat/_snaps/conditions/rmd-stop-error-auto-entrace.txt
@@ -4,9 +4,10 @@ processing file: ressources/with-stop-error-auto-entrace.Rmd
 Error in `h()`:
 ! !
 Backtrace:
- 1. global f()
- 2. global g()
- 3. global h()
+    ▆
+ 1. └─global f()
+ 2.   └─global g()
+ 3.     └─global h()
 
 Quitting from lines 6-10 [unnamed-chunk-1] (ressources/with-stop-error-auto-entrace.Rmd)
 Execution halted

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -174,6 +174,7 @@ test_that("Error can be entraced and correctly handled in outputs", {
   rscript <- withr::local_tempfile(fileext = ".R")
   out2 <- normalizePath(withr::local_tempfile(fileext = ".md"), winslash = "/", mustWork = FALSE)
   writeLines(c(
+    "testthat::local_reproducible_output()",
     "options(knitr.chunk.error = FALSE)",
     sprintf('knitr::knit("%s", output = "%s")', test_path("ressources/with-stop-error-auto-entrace.Rmd"), out2)
     ), con = rscript)
@@ -181,6 +182,7 @@ test_that("Error can be entraced and correctly handled in outputs", {
   expect_snapshot_file(out, name = 'rmd-stop-error-auto-entrace.txt')
 
   writeLines(c(
+      "testthat::local_reproducible_output()",
       "options(knitr.chunk.error = FALSE)",
       sprintf('res <- knitr::knit("%s", output = "%s")', test_path("ressources/with-abort-error.Rmd"), out2)
     ), con = rscript)


### PR DESCRIPTION
rlang 1.1.5 has been released recently and it impacts snapshot by fixing the traceback. 

This PR add minimum requirement and update the snapshot. 

Related to CI error in #235 