### PR TITLE
Be more careful when detecting grid graphics from call object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * `evaluate()` uses `ragg::agg_capture()` this supports more modern graphics
   capabilities than `pdf()`, and should generally be faster (#238).
 * `evaluate()` once again doesn't open a device if `new_device = FALSE` (#234)
+* Fixed an issue where `evaluate()` was unexpectedly erroring when attempting to capture plot outputs (#244).
 
 # evaluate 1.0.3
 

--- a/R/graphics.R
+++ b/R/graphics.R
@@ -42,7 +42,7 @@ makes_visual_change <- function(plot) {
       }
     } else if (is.call(x)) {
       # grid graphics
-      if (as.character(x[[1]]) != "requireNamespace") {
+      if (!"requireNamespace" %in% as.character(x[[1]])) {
         return(TRUE)
       }
     }

--- a/R/graphics.R
+++ b/R/graphics.R
@@ -42,7 +42,7 @@ makes_visual_change <- function(plot) {
       }
     } else if (is.call(x)) {
       # grid graphics
-      if (!"requireNamespace" %in% as.character(x[[1]])) {
+      if (!identical(as.character(x[[1]]), "requireNamespace")) {
         return(TRUE)
       }
     }

--- a/tests/testthat/test-graphics.R
+++ b/tests/testthat/test-graphics.R
@@ -293,3 +293,20 @@ test_that("falls back to pdf() if ragg not available", {
   # Group definition failed
   expect_output_types(ev, c("source", "warning", "plot"))
 })
+
+
+test_that("makes_visual_change() helper can handle stack traces with complex expressions", {
+  # A mocked recordPlot() data structure with a complex expression in the stack trace
+  mocked_plot_record <- list(
+    list(
+      list(),
+      list(
+        rlang::expr(pkg::foo())
+      )
+    )
+  )
+
+  expect_no_error(
+    makes_visual_change(mocked_plot_record)
+  )
+})


### PR DESCRIPTION
This PR fixes an error I was seeing when running `rmarkdown::render('README.Rmd')` on [thematic's README.Rmd](https://github.com/rstudio/thematic/blob/main/README.Rmd).

Apologies for not having a more minimal reprex, but the problem boils down to the fact that `is.call(x)` returns `TRUE` for `language` objects, which can have this behavior:

```r
x <- expr(pkg::foo())
is.call(x)
#> [1] TRUE
as.character(x[[1]])
#> [1] "::"  "pkg" "foo"
```

So, this change is just more careful about the fact that `as.character(x[[1]])` can have length greater than 1.


```r
> rmarkdown::render("README.Rmd")


processing file: README.Rmd
  |.....................................               |  71% [ggrepel]        

Error in `if (as.character(x[[1]]) != "requireNamespace") ...`:
! the condition has length > 1
Backtrace:
     ▆
  1. ├─rmarkdown::render("README.Rmd")
  2. │ └─knitr::knit(knit_input, knit_output, envir = envir, quiet = quiet)
  3. │   └─knitr:::process_file(text, output)
  4. │     ├─xfun:::handle_error(...)
  5. │     ├─base::withCallingHandlers(...)
  6. │     └─knitr:::process_group(group)
  7. │       └─knitr:::call_block(x)
  8. │         └─knitr:::block_exec(params)
  9. │           └─knitr:::eng_r(options)
 10. │             ├─knitr:::in_input_dir(...)
 11. │             │ └─knitr:::in_dir(input_dir(), expr)
 12. │             └─knitr (local) evaluate(...)
 13. │               └─evaluate::evaluate(...)
 14. │                 ├─base::withRestarts(...) at evaluate/R/evaluate.R:149:5
 15. │                 │ └─base (local) withRestartList(expr, restarts)
 16. │                 │   ├─base (local) withOneRestart(withRestartList(expr, restarts[-nr]), restarts[[nr]])
 17. │                 │   │ └─base (local) doWithOneRestart(return(expr), restart)
 18. │                 │   └─base (local) withRestartList(expr, restarts[-nr])
 19. │                 │     └─base (local) withOneRestart(expr, restarts[[1L]])
 20. │                 │       └─base (local) doWithOneRestart(return(expr), restart)
 21. │                 ├─evaluate:::with_handlers(...) at evaluate/R/evaluate.R:149:5
 22. │                 │ ├─base::eval(call) at evaluate/R/conditions.R:52:3
 23. │                 │ │ └─base::eval(call)
 24. │                 │ └─base::withCallingHandlers(...)
 25. │                 └─watcher$print_value(ev$value, ev$visible, envir) at evaluate/R/evaluate.R:155:13
 26. │                   └─evaluate (local) capture_plot_and_output() at evaluate/R/watchout.R:101:5
 27. │                     └─evaluate (local) capture_plot() at evaluate/R/watchout.R:91:5
 28. │                       └─evaluate:::makes_visual_change(plot[[1]]) at evaluate/R/watchout.R:69:5
 29. └─base::.handleSimpleError(...) at evaluate/R/graphics.R:45:7
 30.   └─evaluate (local) h(simpleError(msg, call))
 31.     └─watcher$capture_plot_and_output() at evaluate/R/conditions.R:29:7
 32.       └─evaluate (local) capture_plot() at evaluate/R/watchout.R:91:5
 33.         └─evaluate:::makes_visual_change(plot[[1]]) at evaluate/R/watchout.R:69:5

Quitting from README.Rmd:136-144 [ggrepel]
```